### PR TITLE
Arrange Act Assert

### DIFF
--- a/Evolution.Test.Unit/UnitTests/EvolutionRepoTests.cs
+++ b/Evolution.Test.Unit/UnitTests/EvolutionRepoTests.cs
@@ -25,7 +25,6 @@ namespace Evolution.Test.Unit
                 .AddGetEvolutionBehavior(evolutions)
                 .Context;
 
-            
             //Act
             var repo = new EvolutionRepo(context);
             var executedEvolutions = repo.GetExecutedEvolutionFileNames();
@@ -78,6 +77,7 @@ namespace Evolution.Test.Unit
             {
                 success = false;
             }
+
             //Assert
             Assert.True(success);
         }

--- a/Evolution.Test.Unit/UnitTests/EvolutionRepoTests.cs
+++ b/Evolution.Test.Unit/UnitTests/EvolutionRepoTests.cs
@@ -13,6 +13,7 @@ namespace Evolution.Test.Unit
         [Trait("Category", "unit")]
         public void GetExecutedEvolutions()
         {
+            //Arrange
             var evolutions = new List<IEvolution>()
             {
                 new Data.Entity.Evolution() { Name = "Evolution1" },
@@ -24,9 +25,12 @@ namespace Evolution.Test.Unit
                 .AddGetEvolutionBehavior(evolutions)
                 .Context;
 
+            
+            //Act
             var repo = new EvolutionRepo(context);
             var executedEvolutions = repo.GetExecutedEvolutionFileNames();
 
+            //Assert
             Assert.Equal(evolutions.Count, executedEvolutions.Length);
         }
 
@@ -54,6 +58,7 @@ namespace Evolution.Test.Unit
         [Trait("Category", "unit")]
         public void ExecuteEvolution_Success()
         {
+            //Arrange
             var success = false;
             const string evolutionContent = "select sysdate from dual;";
 
@@ -61,6 +66,7 @@ namespace Evolution.Test.Unit
                 .AddGetEvolutionBehavior(new List<IEvolution>())
                 .Context;
 
+             //Act
             var repo = new EvolutionRepo(context);
 
             try
@@ -72,7 +78,7 @@ namespace Evolution.Test.Unit
             {
                 success = false;
             }
-
+            //Assert
             Assert.True(success);
         }
     }


### PR DESCRIPTION
Arrange-Act-Assert"
a pattern for arranging and formatting code in UnitTest methods:
Each method should group these functional sections, separated by blank lines:
Arrange all necessary preconditions and inputs.
Act on the object or method under test.
Assert that the expected results have occurred.